### PR TITLE
Added target directory, removed suffix

### DIFF
--- a/src/DynamoMigratorExtension.cs
+++ b/src/DynamoMigratorExtension.cs
@@ -36,7 +36,7 @@ namespace DynamoXMLToJsonMigrator
             }
         }
 
-        private string selectedSourceDirectory = "No directory selected";
+        private string selectedSourceDirectory = "No source directory selected";
         /// <summary>
         /// The selected source directory of dynamo files to be migrated.
         /// </summary>
@@ -53,15 +53,9 @@ namespace DynamoXMLToJsonMigrator
             }
         }
 
-        public string selectedTargetDirectoryDefault
-        {
-            get
-            {
-                return "No target directory selected, files will be overwritten in source directory.";
-            }
-        }
+        public const string selectedTargetDirectoryDefault = "No target directory selected, files will be overwritten in source directory.";
 
-        private string selectedTargetDirectory = "No target directory selected, files will be overwritten in source directory.";
+        private string selectedTargetDirectory = selectedTargetDirectoryDefault;
         /// <summary>
         /// The selected target directory of dynamo files to be migrated.
         /// </summary>

--- a/src/DynamoMigratorExtension.cs
+++ b/src/DynamoMigratorExtension.cs
@@ -22,8 +22,9 @@ namespace DynamoXMLToJsonMigrator
             {
                 return
                 "This extension will automate the process of converting XML Dynamo files to JSON based 2.0 files.\n"+
-                "Select a directory which contains Dynamo files and press Migrate.\n"+
-                "Files will have _jsonMigrated appended to their names and will be saved into the same directory.";
+                "Select a source directory which contains Dynamo files and press Migrate.\n"+
+                "Optionally, you can also specify a target directory.\n"+
+                "Files will be saved to the target directory, or if none is given the source files will be overwritten in the source directory.";
             }
         }
 
@@ -35,20 +36,45 @@ namespace DynamoXMLToJsonMigrator
             }
         }
 
-        private string selectedDirectory = "No directory selected";
+        private string selectedSourceDirectory = "No directory selected";
         /// <summary>
-        /// The selected directory of dynamo files to be migrated.
+        /// The selected source directory of dynamo files to be migrated.
         /// </summary>
-        public string SelectedDirectory
+        public string SelectedSourceDirectory
         {
             get
             {
-                return this.selectedDirectory;
+                return this.selectedSourceDirectory;
             }
             set
             {
-                selectedDirectory = value;
-                RaisePropertyChanged(nameof(SelectedDirectory));
+                selectedSourceDirectory = value;
+                RaisePropertyChanged(nameof(SelectedSourceDirectory));
+            }
+        }
+
+        public string selectedTargetDirectoryDefault
+        {
+            get
+            {
+                return "Optional";
+            }
+        }
+
+        private string selectedTargetDirectory = "Optional";
+        /// <summary>
+        /// The selected target directory of dynamo files to be migrated.
+        /// </summary>
+        public string SelectedTargetDirectory
+        {
+            get
+            {
+                return this.selectedTargetDirectory;
+            }
+            set
+            {
+                selectedTargetDirectory = value;
+                RaisePropertyChanged(nameof(SelectedTargetDirectory));
             }
         }
 

--- a/src/DynamoMigratorExtension.cs
+++ b/src/DynamoMigratorExtension.cs
@@ -57,11 +57,11 @@ namespace DynamoXMLToJsonMigrator
         {
             get
             {
-                return "Optional";
+                return "No target directory selected, files will be overwritten in source directory.";
             }
         }
 
-        private string selectedTargetDirectory = "Optional";
+        private string selectedTargetDirectory = "No target directory selected, files will be overwritten in source directory.";
         /// <summary>
         /// The selected target directory of dynamo files to be migrated.
         /// </summary>

--- a/src/migrationWindow.xaml
+++ b/src/migrationWindow.xaml
@@ -7,12 +7,12 @@
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300" Title="DynamoMigrationExtension">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
-    <StackPanel Name="MainPanel"  
+        <StackPanel Name="MainPanel"  
                 Background="#2d2d2d"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch">
 
-        <TextBlock Name="info"
+            <TextBlock Name="info"
                    HorizontalAlignment="Stretch"
                    VerticalAlignment="Stretch"
                    MinWidth="200"
@@ -24,35 +24,52 @@
                    TextWrapping="Wrap"
                    Foreground="White"/>
 
-        <Button Name="select"
+            <Button Name="selectSource"
                 Padding="5" 
                 HorizontalAlignment="Left"
                 VerticalAlignment="Top"
-                Content="Select Directory"
-                Click="select_Click" Margin=" 5">
+                Content="Select Source Directory"
+                Click="selectSource_Click" Margin=" 5">
 
-        </Button>
-        <TextBlock 
+            </Button>
+            <TextBlock 
                    HorizontalAlignment="Left"
                    VerticalAlignment="Top"
                    MinWidth="200"
-                   Text="{Binding SelectedDirectory}"
+                   Text="{Binding SelectedSourceDirectory}"
                    FontFamily="Arial" 
                    Padding="10" 
                    FontWeight="Light" 
                    FontSize="12"
                    Margin="5"
                    Foreground="White"/>
-        <Button Name="migrate"
+            <Button x:Name="selectTarget"
+                Padding="5" 
+                HorizontalAlignment="Left"
+                VerticalAlignment="Top"
+                Content="Select Target Directory"
+                Click="selectTarget_Click" Margin=" 5"/>
+            <TextBlock 
+                HorizontalAlignment="Left"
+                VerticalAlignment="Top"
+                MinWidth="200"
+                Text="{Binding SelectedTargetDirectory}"
+                FontFamily="Arial" 
+                Padding="10" 
+                FontWeight="Light" 
+                FontSize="12"
+                Margin="5"
+                Foreground="White"/>
+            <Button Name="migrate"
                 Padding="5" 
                 HorizontalAlignment="Left" 
                 VerticalAlignment="Top" 
                 Content="Migrate" 
                 Click="migrate_Click"
                 Margin="5">
-               
-        </Button>
-        <TextBlock Name="output"
+
+            </Button>
+            <TextBlock x:Name="output"
                    HorizontalAlignment="Stretch"
                    VerticalAlignment="Stretch"
                    MinWidth="200"
@@ -63,7 +80,7 @@
                    FontSize="12"
                    TextWrapping="Wrap"
                    Foreground="White"/>
-    </StackPanel>
+        </StackPanel>
     </ScrollViewer>
 
 </Window>

--- a/src/migrationWindow.xaml.cs
+++ b/src/migrationWindow.xaml.cs
@@ -28,7 +28,7 @@ namespace DynamoXMLToJsonMigrator
                 (this.DataContext as DynamoMigratorExtension).Output = String.Format("Could not access directory at: {0}.", sourcePath);
                 return;
             }
-            else if (migrationExtension.SelectedTargetDirectory != migrationExtension.selectedTargetDirectoryDefault)
+            else if (migrationExtension.SelectedTargetDirectory != DynamoMigratorExtension.selectedTargetDirectoryDefault)
             {
                 targetPath = migrationExtension.SelectedTargetDirectory;
                 targetDirectoryIsSet = true;

--- a/src/migrationWindow.xaml.cs
+++ b/src/migrationWindow.xaml.cs
@@ -20,21 +20,21 @@ namespace DynamoXMLToJsonMigrator
         private void migrate_Click(object sender, RoutedEventArgs e)
         {
             var migrationExtension = (this.DataContext as DynamoMigratorExtension);
-            var sourcepath = migrationExtension.SelectedSourceDirectory;
-            var targetpath = sourcepath;
-            var replacedir = false;
-            if (!Directory.Exists(sourcepath))
+            var sourcePath = migrationExtension.SelectedSourceDirectory;
+            var targetPath = sourcePath;
+            var targetDirectoryIsSet = false;
+            if (!Directory.Exists(sourcePath))
             {
-                (this.DataContext as DynamoMigratorExtension).Output = String.Format("Could not access directory at: {0}.", sourcepath);
+                (this.DataContext as DynamoMigratorExtension).Output = String.Format("Could not access directory at: {0}.", sourcePath);
                 return;
             }
             else if (migrationExtension.SelectedTargetDirectory != migrationExtension.selectedTargetDirectoryDefault)
             {
-                targetpath = migrationExtension.SelectedTargetDirectory;
-                replacedir = true;
+                targetPath = migrationExtension.SelectedTargetDirectory;
+                targetDirectoryIsSet = true;
             }
             var dynamoViewModel = (this.Owner.DataContext as DynamoViewModel);
-            var files = System.IO.Directory.EnumerateFiles(sourcepath);
+            var files = System.IO.Directory.EnumerateFiles(sourcePath);
             //clear the output before this migration run.
             migrationExtension.Output = "";
             foreach (var file in files)
@@ -43,9 +43,9 @@ namespace DynamoXMLToJsonMigrator
                 if (ext == ".dyn" || ext == ".dyf")
                 {
                     var newfilepath = file;
-                    if (replacedir)
+                    if (targetDirectoryIsSet)
                     {
-                        newfilepath = file.Replace(sourcepath, targetpath);
+                        newfilepath = file.Replace(sourcePath, targetPath);
                     }
                     dynamoViewModel.OpenCommand.Execute(file);
                     dynamoViewModel.SaveAsCommand.Execute(newfilepath);


### PR DESCRIPTION
This adds a second directory selection button for a target directory along with the necessary logic and it removes any code related to suffixes for migrated files. (Item 2 from issue #3 )
![grafik](https://user-images.githubusercontent.com/3014437/37753944-ae643d30-2d9f-11e8-93a3-042474369a5b.png)
