### PR TITLE
Adding notes regarding the clockwork package to the migration extension

### DIFF
--- a/src/DynamoMigratorExtension.cs
+++ b/src/DynamoMigratorExtension.cs
@@ -24,7 +24,8 @@ namespace DynamoXMLToJsonMigrator
                 "This extension will automate the process of converting XML Dynamo files to JSON based 2.0 files.\n"+
                 "Select a source directory which contains Dynamo files and press Migrate.\n"+
                 "Optionally, you can also specify a target directory.\n"+
-                "Files will be saved to the target directory, or if none is given the source files will be overwritten in the source directory.";
+                "Files will be saved to the target directory, or if none is given the source files will be overwritten in the source directory.\n"+
+                "Note: For clockwork package, it is recommended to migrate the files in batch's of 75-100 due to large number of nodes in there.";
             }
         }
 

--- a/src/DynamoMigratorExtension.cs
+++ b/src/DynamoMigratorExtension.cs
@@ -25,7 +25,7 @@ namespace DynamoXMLToJsonMigrator
                 "Select a source directory which contains Dynamo files and press Migrate.\n"+
                 "Optionally, you can also specify a target directory.\n"+
                 "Files will be saved to the target directory, or if none is given the source files will be overwritten in the source directory.\n"+
-                "Note: For clockwork package, it is recommended to migrate the files in batch's of 75-100 due to large number of nodes in there.";
+                "Note: For clockwork package, it is recommended to migrate the files in batch's of 50-100 at once. Close the dynamo window and open it again before running the next batch of files.";
             }
         }
 

--- a/src/DynamoMigratorExtension.cs
+++ b/src/DynamoMigratorExtension.cs
@@ -25,7 +25,7 @@ namespace DynamoXMLToJsonMigrator
                 "Select a source directory which contains Dynamo files and press Migrate.\n"+
                 "Optionally, you can also specify a target directory.\n"+
                 "Files will be saved to the target directory, or if none is given the source files will be overwritten in the source directory.\n"+
-                "Note: For clockwork package, it is recommended to migrate the files in batch's of 50-100 at once. Close the dynamo window and open it again before running the next batch of files.";
+                "Note: For larger packages, it is recommended to migrate the files in batch's of 50-100 at once. Close the dynamo window and open it again before running the next batch of files.";
             }
         }
 


### PR DESCRIPTION
Clockwork package for 1.3 has around 406 .dyf files. If we run the migration extension tool on all these files at once, memory leak occurs eventually and leads to a dynamo crash. We will be recommending users to split the files into each batch containing 50-100 files and then run the migration tool. 
Also users will have to close the dynamo window after running one batch of files to avoid going into not responding state sometimes. 